### PR TITLE
ER14/Case1

### DIFF
--- a/ER14/Case Study 1/README.md
+++ b/ER14/Case Study 1/README.md
@@ -1,0 +1,53 @@
+# ER14
+
+### Table Of Content
+
+- [Case Study](#case-study)
+- [Problem](#problem)
+- [Solution](#solution)
+- [Step By Step](#step-by-step)
+- [Parts Replaced](#parts-replaced)
+- [Time Spent](#time-spent)
+
+### Case Study
+
+CubeX 28 was experiencing a permanent ER14 on power up. According to factory documentation, ER14 is related to OP Board so the CubeX was sent back for technical service to repair.
+
+### Problem
+
+OP Board was an older version v1.3
+
+### Solution
+
+Replaced OP Board with the newer model: OP Board v1.4
+
+### Step by Step
+
+1. Tested CubeX 28 to validate error code
+
+2. Once error code is validated, proceeded with OP Board replacement
+
+3. Checked if DIP switch was set to correct vertical: Medical or Vet
+
+4. Powered on CubeX 28 and checked C and P Calibration Data using the Original Factory Calibration Data.
+
+5. Performed stress test for CubeX 28
+    - 1 Shot at 40kvp 0.4mas
+    - 3 Shots at 50kvp 5mas
+    - 3 Shots at 70kvp 5mas
+    - 1 Shot at 90kvp 5mas
+    - 1 Shot at 90kvp 80mas
+
+6. CubeX passed stress test and is deemed repaired
+
+### Parts replaced
+
+Broken Part: OP Board v1.3
+Serial Number: POP211105-031
+
+New Part: OP Board v1.4
+Serial Number: POP240724-049
+
+### Time Spent
+
+Total Time Spent: 21 Minutes

--- a/ER14/README.md
+++ b/ER14/README.md
@@ -1,0 +1,3 @@
+# ER14
+
+Here lies a collection of case studies related to CubeX 28 that only had ER14


### PR DESCRIPTION
# New Case study:

CubeX 28 was experiencing a permanent ER14 on power up. According to factory documentation, ER14 is related to OP Board so the CubeX was sent back for technical service to repair.